### PR TITLE
Have VCS wait for a free network license.

### DIFF
--- a/cocotb_testrunner.py
+++ b/cocotb_testrunner.py
@@ -102,7 +102,7 @@ class CocotbTest:
                 args_incdirs.append("+incdir+{}".format(incdir))
 
         sim_args = "+lint=all"
-        compile_args = "+lint=all -timescale=1ns/10ps " +\
+        compile_args = "+lint=all +vcs+lic+wait -timescale=1ns/10ps " +\
             ' '.join(args_hdl_params) + ' ' +\
             ' '.join(args_incdirs)
 


### PR DESCRIPTION
Useful for running several jobs in parallel, especially for CI tests, as this avoids test failure due to an insufficient amount of available licenses.